### PR TITLE
Add Docker setup for IoTGoat with QEMU and QCOW2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Several methods exist to get started with hacking IoTGoat.
 
 4. Use the `IoTGoat-raspberry-pi2-sysupgrade.img` firmware to flash on a Raspberry Pi 2 (BRCM2708 & BRCM2709).
 
+5. Use the Docker setup to run IoTGoat in a containerized environment. Refer to the [Docker](/docker/README.md) setup guide for more details.
+
 Refer to the [Getting started](https://github.com/OWASP/IoTGoat/wiki/Getting-started) page for additional details and screencaptures.
 
 ### Building from source
@@ -58,6 +60,8 @@ The first build will take some time to complete and will vary based on the provi
 * Abhinav Mohanty (cyanide284)
 * Jason Andress (@jandress)
 * @0x48piraj
+* Abdallah Ajjawi (@lefanous)
+* Amar Djebarra (@GeekMuch)
 
 ### Screenshots
 

--- a/docker/Dockerfile.qemu
+++ b/docker/Dockerfile.qemu
@@ -1,0 +1,35 @@
+# Use a base image with QEMU installed
+FROM ubuntu:20.04
+
+# Install necessary packages including OpenSSH
+RUN apt-get update && apt-get install -y \
+    qemu-system-x86 \
+    qemu-utils \
+    openssh-server \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /opt
+
+# Copy the local IoTGoat image (should be added to the docker directory manually)
+# Fetch the latest image from https://github.com/OWASP/IoTGoat/releases/latest
+# Convert the image to a qcow2 format using the following command:
+# qemu-img convert -f raw -O qcow2 /path/to/IoTGoat-x86.vmdk /path/to/IoTGoat-x86.qcow2
+COPY ./IoTGoat-x86.qcow2 /opt/IoTGoat-x86.qcow2
+
+# Expose necessary ports for SSH (22), HTTP (80), HTTPS (443), and Web interface (5000)
+EXPOSE 2222 8080 4443 
+
+# Configure SSH server to generate stronger host keys (overwrite if they exist)
+RUN ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" -q -y && \
+    ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" -q -y && \
+    sed -i 's/#HostKey \/etc\/ssh\/ssh_host_ecdsa_key/HostKey \/etc\/ssh\/ssh_host_ecdsa_key/' /etc/ssh/sshd_config && \
+    sed -i 's/#HostKey \/etc\/ssh\/ssh_host_ed25519_key/HostKey \/etc\/ssh\/ssh_host_ed25519_key/' /etc/ssh/sshd_config
+
+# Restart SSH service to apply the changes
+RUN service ssh restart
+
+# Run QEMU with IoTGoat image and network forwarding
+CMD ["qemu-system-x86_64", "-hda", "/opt/IoTGoat-x86.qcow2", "-m", "2048", "-smp", "2", \
+    "-netdev", "user,id=mynet0,hostfwd=tcp::2222-:22,hostfwd=tcp::8080-:80,hostfwd=tcp::4443-:443,hostfwd=tcp::5000-:5000", \
+    "-device", "e1000,netdev=mynet0", "-nographic", "-display", "none"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,153 @@
+# IoTGoat QEMU Docker Setup Guide
+
+This guide provides the option to run a virtualized IoTGoat environment using Docker and Docker Compose, allowing access via SSH, HTTP, and HTTPS. This guide will walk you through the setup process, the prerequisites, and how to build and run the Docker container.
+
+## Prerequisites
+
+To run this environment, ensure you have the following installed:
+
+1. [Docker](https://www.docker.com/get-started)
+   - Docker is used to create and run the containerized environment.
+2. [Docker Compose](https://docs.docker.com/compose/install/)
+   - Docker Compose simplifies the orchestration of multi-container Docker applications.
+3. [QEMU](https://www.qemu.org/download/)
+   - QEMU is used to convert the IoTGoat image to qcow2 format.
+4. [IoTGoat - Latest Release](https://github.com/OWASP/IoTGoat/releases/latest)
+   - The IoTGoat image is used to run the IoT environment.
+   - The image is required to be in qcow2 format.
+
+## Files Overview
+
+- **Dockerfile.qemu**: This Dockerfile defines the base Ubuntu image and installs QEMU, SSH, and other necessary components.
+- **docker-compose.yml**: This file defines the services and networking configurations for Docker Compose.
+- **IoTGoat-x86.qcow2**: This is the manually added IoTGoat image (in qcow2 format) that QEMU will use to run the IoT environment.
+
+## Setup Instructions
+
+### 1. Clone the Repository
+
+First, clone the repository to your local machine.
+
+```bash
+git clone https://github.com/OWASP/IoTGoat
+cd IoTGoat
+```
+
+### 2. Fetch and Convert the IoTGoat Image
+
+Download the latest IoTGoat image (IoTGoat-x86.img.gz) from the [releases page](https://github.com/OWASP/IoTGoat/releases/latest) and convert it to qcow2 format using the following command:
+
+Unzip the file and convert it to qcow2 format using the following command:
+
+```bash
+gunzip IoTGoat-x86.img.gz
+qemu-img convert -f raw -O qcow2 IoTGoat-x86.img IoTGoat-x86.qcow2
+```
+
+The image should be added to the `docker` directory.
+
+### 3. Project Structure
+
+Ensure your project directory looks like this:
+
+```
+IoTGoat/
+│
+├── docker/                       # Docker files and configs
+│   ├── Dockerfile.qemu           # QEMU environment setup
+│   ├── docker-compose.yml        # Docker Compose config
+│   ├── IoTGoat-x86.qcow2         # QCOW image (add manually)
+│   └── README.md                 # Docker and QCOW setup instructions
+│...
+```
+
+### 4. Build and Run the Docker Container
+
+To build and run the IoTGoat QEMU environment, use the following command:
+
+```bash
+docker compose up --build
+```
+
+This will:
+
+- Build the QEMU image using the Dockerfile.qemu.
+- Run the container and expose the following services:
+  - **SSH** on port `2222`
+  - **HTTP** on port `8080`
+  - **HTTPS/Web interface** on port `4443`
+
+### 5. Accessing the Services
+
+After running `docker-compose up --build`, the following services will be available:
+
+#### SSH Access
+
+To connect to the IoTGoat environment via SSH, run:
+
+```bash
+ssh -o HostKeyAlgorithms=+ssh-rsa iotgoatuser@localhost -p 2222
+```
+
+You may be prompted for a password.
+
+#### HTTP Access
+
+To access the IoTGoat web environment via HTTP, open a browser and navigate to:
+
+```bash
+http://localhost:8080
+```
+
+#### Web Interface (HTTPS)
+
+To access the IoTGoat web interface via HTTPS, navigate to:
+
+```bash
+https://localhost:4443
+```
+
+### 6. Stopping the Container
+
+To stop the running container, press `CTRL+C` in the terminal running Docker Compose, or use:
+
+```bash
+docker-compose down
+```
+
+This will stop and remove the container.
+
+### 7. Persistent Data
+
+The IoTGoat environment is configured to persist its data inside a Docker volume. The volume is mapped to the `/opt` directory inside the container, so any data generated will not be lost when the container is stopped.
+
+To remove the volume and reset the environment, use:
+
+```bash
+docker-compose down -v
+```
+
+### 8. Rebuilding the Container
+
+If you make changes to the `Dockerfile.qemu` or the project files, rebuild the container using:
+
+```bash
+docker-compose up --build
+```
+
+---
+
+### Notes
+
+- Verify SSH configuration and exposed ports to mitigate potential security risks and usage of default credentials.
+- Ensure Docker and Docker Compose are correctly installed and running on your system.
+- If you encounter any issues with ports, ensure that the ports specified in `docker-compose.yml` (2222, 8080, 4443) are available on your host system.
+- For a clean environment reset, use `docker-compose down -v` to remove volumes and the container.
+- QEMU does not have to be installed on the host machine. It is installed on the Docker image.
+- Ensure proper permissions for the `IoTGoat-x86.qcow2` file. Especially if Docker cannot access it. Run the following command to fix it:
+
+```bash
+chmod 644 /path/to/IoTGoat-x86.qcow2
+```
+
+---

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ To run this environment, ensure you have the following installed:
 2. [Docker Compose](https://docs.docker.com/compose/install/)
    - Docker Compose simplifies the orchestration of multi-container Docker applications.
 3. [QEMU](https://www.qemu.org/download/)
-   - QEMU is used to convert the IoTGoat image to qcow2 format.
+   - The `qemu-img` tool from QEMU is used to convert the IoTGoat image to the qcow2 format.
 4. [IoTGoat - Latest Release](https://github.com/OWASP/IoTGoat/releases/latest)
    - The IoTGoat image is used to run the IoT environment.
    - The image is required to be in qcow2 format.
@@ -89,7 +89,7 @@ To connect to the IoTGoat environment via SSH, run:
 ssh -o HostKeyAlgorithms=+ssh-rsa iotgoatuser@localhost -p 2222
 ```
 
-You may be prompted for a password.
+You will be prompted for a password when connecting via SSH. As part of the IoTGoat task, your objective is to find this password.
 
 #### HTTP Access
 
@@ -143,7 +143,7 @@ docker-compose up --build
 - Ensure Docker and Docker Compose are correctly installed and running on your system.
 - If you encounter any issues with ports, ensure that the ports specified in `docker-compose.yml` (2222, 8080, 4443) are available on your host system.
 - For a clean environment reset, use `docker-compose down -v` to remove volumes and the container.
-- QEMU does not have to be installed on the host machine. It is installed on the Docker image.
+- QEMU is required on the host machine solely for using the qemu-img tool to convert the IoTGoat image to qcow2 format. It is not needed for any other tasks on the host.
 - Ensure proper permissions for the `IoTGoat-x86.qcow2` file. Especially if Docker cannot access it. Run the following command to fix it:
 
 ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ To run this environment, ensure you have the following installed:
 
 ### 1. Clone the Repository
 
-First, clone the repository to your local machine.
+First, clone the repository to your local machine:
 
 ```bash
 git clone https://github.com/OWASP/IoTGoat

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+name: IoTGoat-qemu
+services:
+  iotgoat:
+    build:
+      context: .
+      dockerfile: Dockerfile.qemu
+    container_name: iotgoat-qemu
+    tty: true
+    stdin_open: true
+    ports:
+      - "2222:2222" # SSH
+      - "8080:8080" # HTTP
+      - "4443:4443" # HTTPS / Web interface

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-name: IoTGoat-qemu
+name: iotgoat-qemu
 services:
   iotgoat:
     build:


### PR DESCRIPTION
**Description:**

This PR adds Docker support for running IoTGoat with QEMU, allowing the use of a QCOW2 image for virtualization.

It includes:

- A Dockerfile.qemu for setting up the QEMU environment.
- docker-compose.yml for simplified service orchestration.
- Instructions in the docker/README.md to guide users on fetching the QCOW2 image and running the environment using Docker.
- This resolves the need for containerized virtualization discussed in Issue #4.

**Changes:**

- Added Docker setup for IoTGoat with QEMU and QCOW2 support.
- Updated project structure to support Docker files.
- Provided documentation for setup and usage.

This closes [#4](https://github.com/OWASP/IoTGoat/issues/4).