### PR TITLE
Feature/docker autofetch img

### DIFF
--- a/docker/Dockerfile.qemu
+++ b/docker/Dockerfile.qemu
@@ -6,16 +6,12 @@ RUN apt-get update && apt-get install -y \
     qemu-system-x86 \
     qemu-utils \
     openssh-server \
+    wget \
+    gzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /opt
-
-# Copy the local IoTGoat image (should be added to the docker directory manually)
-# Fetch the latest image from https://github.com/OWASP/IoTGoat/releases/latest
-# Convert the image to a qcow2 format using the following command:
-# qemu-img convert -f raw -O qcow2 /path/to/IoTGoat-x86.vmdk /path/to/IoTGoat-x86.qcow2
-COPY ./IoTGoat-x86.qcow2 /opt/IoTGoat-x86.qcow2
 
 # Expose necessary ports for SSH (22), HTTP (80), HTTPS (443), and Web interface (5000)
 EXPOSE 2222 8080 4443 
@@ -29,7 +25,9 @@ RUN ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" -q -y && \
 # Restart SSH service to apply the changes
 RUN service ssh restart
 
-# Run QEMU with IoTGoat image and network forwarding
-CMD ["qemu-system-x86_64", "-hda", "/opt/IoTGoat-x86.qcow2", "-m", "2048", "-smp", "2", \
-    "-netdev", "user,id=mynet0,hostfwd=tcp::2222-:22,hostfwd=tcp::8080-:80,hostfwd=tcp::4443-:443,hostfwd=tcp::5000-:5000", \
-    "-device", "e1000,netdev=mynet0", "-nographic", "-display", "none"]
+# Copy the entrypoint script
+COPY entrypoint.sh /opt/entrypoint.sh
+RUN chmod +x /opt/entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/docker/Dockerfile.qemu
+++ b/docker/Dockerfile.qemu
@@ -25,6 +25,9 @@ RUN ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" -q -y && \
 # Restart SSH service to apply the changes
 RUN service ssh restart
 
+# Copy these if the exist
+COPY IoTGoat-x86.* /opt/
+
 # Copy the entrypoint script
 COPY entrypoint.sh /opt/entrypoint.sh
 RUN chmod +x /opt/entrypoint.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,18 +9,13 @@ To run this environment, ensure you have the following installed:
 1. [Docker](https://www.docker.com/get-started)
    - Docker is used to create and run the containerized environment.
 2. [Docker Compose](https://docs.docker.com/compose/install/)
-   - Docker Compose simplifies the orchestration of multi-container Docker applications.
-3. [QEMU](https://www.qemu.org/download/)
-   - The `qemu-img` tool from QEMU is used to convert the IoTGoat image to the qcow2 format.
-4. [IoTGoat - Latest Release](https://github.com/OWASP/IoTGoat/releases/latest)
-   - The IoTGoat image is used to run the IoT environment.
-   - The image is required to be in qcow2 format.
+   - Docker Compose simplifies the orchestration of multi-container Docker applications. Docker Compose is accompanied by docker desktop by default.
 
 ## Files Overview
 
 - **Dockerfile.qemu**: This Dockerfile defines the base Ubuntu image and installs QEMU, SSH, and other necessary components.
 - **docker-compose.yml**: This file defines the services and networking configurations for Docker Compose.
-- **IoTGoat-x86.qcow2**: This is the manually added IoTGoat image (in qcow2 format) that QEMU will use to run the IoT environment.
+- **IoTGoat-x86.qcow2**: (optional) This is the manually added IoTGoat image (in qcow2 format) that QEMU will use to run the IoT environment. This is only necessary if you want to use a specific version of IoTGoat. By default, the docker script will automatically download the latest version
 
 ## Setup Instructions
 
@@ -33,9 +28,9 @@ git clone https://github.com/OWASP/IoTGoat
 cd IoTGoat/docker
 ```
 
-### 2. Fetch and Convert the IoTGoat Image
+### 2. Fetch and Convert the IoTGoat Image (Optional)
 
-Download the latest IoTGoat image (IoTGoat-x86.img.gz) from the [releases page](https://github.com/OWASP/IoTGoat/releases/latest) and convert it to qcow2 format using the following command:
+If you don't want the script to download the latest IoTGoat image and you would like to use a specific version, you can download it from the image (IoTGoat-x86.img.gz) from the [releases page](https://github.com/OWASP/IoTGoat/releases/latest) and convert it to qcow2 format using the following command:
 
 Unzip the file and convert it to qcow2 format using the following command:
 
@@ -46,7 +41,7 @@ qemu-img convert -f raw -O qcow2 IoTGoat-x86.img IoTGoat-x86.qcow2
 
 The image should be added to the `docker` directory.
 
-### 3. Project Structure
+### Project Structure
 
 Ensure your project directory looks like this:
 
@@ -56,7 +51,7 @@ IoTGoat/
 ├── docker/                       # Docker files and configs
 │   ├── Dockerfile.qemu           # QEMU environment setup
 │   ├── docker-compose.yml        # Docker Compose config
-│   ├── IoTGoat-x86.qcow2         # QCOW image (add manually)
+│   ├── IoTGoat-x86.qcow2         # QCOW image (add manually if you want to use a specific version of IoTGoat)
 │   └── README.md                 # Docker and QCOW setup instructions
 │...
 ```
@@ -144,7 +139,7 @@ docker compose up --build
 - If you encounter any issues with ports, ensure that the ports specified in `docker compose.yml` (2222, 8080, 4443) are available on your host system.
 - For a clean environment reset, use `docker compose down -v` to remove volumes and the container.
 - QEMU is required on the host machine solely for using the qemu-img tool to convert the IoTGoat image to qcow2 format. It is not needed for any other tasks on the host.
-- Ensure proper permissions for the `IoTGoat-x86.qcow2` file. Especially if Docker cannot access it. Run the following command to fix it:
+- Ensure proper permissions for the `IoTGoat-x86.qcow2` file if downloaded manually. Especially if Docker cannot access it. Run the following command to fix it:
 
 ```bash
 chmod 644 /path/to/IoTGoat-x86.qcow2

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+QCOW2_FILE="/opt/IoTGoat-x86.qcow2"
+IMG_GZ_FILE="/opt/IoTGoat-x86.img.gz"
+IMG_URL="https://github.com/OWASP/IoTGoat/releases/latest/download/IoTGoat-x86.img.gz"
+
+# Check if qcow2 file already exists
+if [ -f "$QCOW2_FILE" ]; then
+    echo "Found existing qcow2 image. Using it."
+else
+    # If no qcow2, check if gz file exists
+    if [ -f "$IMG_GZ_FILE" ]; then
+        echo "Found IoTGoat-x86.img.gz. Extracting and converting..."
+    else
+        echo "No qcow2 or gz image found. Downloading IoTGoat-x86.img.gz..."
+        wget -O "$IMG_GZ_FILE" "$IMG_URL"
+    fi
+
+    # Decompress and convert the image
+    gunzip -f "$IMG_GZ_FILE"
+    qemu-img convert -f raw -O qcow2 /opt/IoTGoat-x86.img "$QCOW2_FILE"
+    rm -f /opt/IoTGoat-x86.img
+fi
+
+# Run QEMU
+exec qemu-system-x86_64 \
+    -hda "$QCOW2_FILE" \
+    -m 2048 \
+    -smp 2 \
+    -netdev user,id=mynet0,hostfwd=tcp::2222-:22,hostfwd=tcp::8080-:80,hostfwd=tcp::4443-:443,hostfwd=tcp::5000-:5000 \
+    -device e1000,netdev=mynet0 \
+    -nographic \
+    -display none


### PR DESCRIPTION
Updated the dockerfile and added a custom entrypoint script.

The purpose is:

- Make the installation easier. Theres no need for the host to have qemu utils installed because the script can download the latest iotgoat image directly from github using the [latest url construction](https://github.com/OWASP/IoTGoat/releases/latest/download/IoTGoat-x86.img.gz). It will then convert it to qcow2 and use that.
- If the user is still interested in using a specific version, they can still do that by placing the qcow2 file in the docker folder.
- Its also possible to simply place the img.gz file in the same directory, and the script will convert it to qcow2.